### PR TITLE
Add variable existence checking at compile time

### DIFF
--- a/src/object.odin
+++ b/src/object.odin
@@ -414,7 +414,7 @@ stringify_object :: proc(obj: ^Obj) -> string {
 			 * since from the user's perspective they're just functions. */
 		return stringify_function(as_bound_method(obj_val(obj)).method.function)
 	case .CLASS:
-		return fmt.tprintf("%s", as_class(obj_val(obj)).name.chars)
+		return fmt.tprintf("<class %s>", as_class(obj_val(obj)).name.chars)
 	case .CLOSURE:
 		return stringify_function(as_closure(obj_val(obj)).function)
 	case .FUNCTION:

--- a/src/std.odin
+++ b/src/std.odin
@@ -73,9 +73,12 @@ get_builtin_module :: proc(gc: ^GC, module_name: BuiltinModule) -> []ModuleFunct
 	return module_functions[:]
 }
 
-/* These are the functions available in the global scope. Only five functions
- * are available as such. The rest are in their corresponding modules. */
+/* These are the functions available in the global scope. Only five very commonly used
+ * functions are available as such. The rest are in their corresponding modules. */
 init_natives :: proc(gc: ^GC) {
+	/* Add all the names of the globally present native functions to the name list. */
+	append(&gc.global_native_fns, "puts", "gets", "len", "str", "parse", "typeof")
+
 	// io
 	define_native(gc, "puts", puts_native, arity = 1)
 	define_native(gc, "gets", gets_native, arity = 0)

--- a/src/vm.odin
+++ b/src/vm.odin
@@ -313,11 +313,10 @@ run :: proc(vm: ^VM, importer: ImportingModule = nil) -> InterpretResult #no_bou
 		case .OP_GET_GLOBAL:
 			{
 				name := read_string(frame)
-				value: Value;ok: bool
-				if value, ok = table_get(&vm.gc.globals, name); !ok {
-					vm_panic(vm, "Undefined variable '%s'.", name.chars)
-					return .INTERPRET_RUNTIME_ERROR
-				}
+
+				/* No runtime check is done for variable existence since that is
+                 * done at compile time. */
+				value, _ := table_get(&vm.gc.globals, name)
 				vm_push(vm, value)
 			}
 		case .OP_DEFINE_GLOBAL:
@@ -328,11 +327,9 @@ run :: proc(vm: ^VM, importer: ImportingModule = nil) -> InterpretResult #no_bou
 			{
 				name := read_string(frame)
 
-				if table_set(&vm.gc.globals, name, vm_peek(vm, 0)) {
-					table_delete(&vm.gc.globals, name)
-					vm_panic(vm, "Undefined variable '%s'.", name.chars)
-					return .INTERPRET_RUNTIME_ERROR
-				}
+				/* No runtime check is done for variable existence since that is
+                 * done at compile time. */
+				table_set(&vm.gc.globals, name, vm_peek(vm, 0))
 			}
 		case .OP_GET_UPVALUE:
 			{

--- a/test/__tests__/class/empty.zn
+++ b/test/__tests__/class/empty.zn
@@ -1,3 +1,3 @@
 class Foo {}
 
-print Foo // expect: Foo
+print Foo // expect: <class Foo>

--- a/test/__tests__/class/local_reference_self.zn
+++ b/test/__tests__/class/local_reference_self.zn
@@ -5,5 +5,5 @@
         }
     }
 
-    print Foo().return_self() // expect: Foo
+    print Foo().return_self() // expect: <class Foo>
 }

--- a/test/__tests__/class/reference_self.zn
+++ b/test/__tests__/class/reference_self.zn
@@ -4,4 +4,4 @@ class Foo {
     }
 }
 
-print Foo().return_self() // expect: Foo
+print Foo().return_self() // expect: <class Foo>

--- a/test/__tests__/variable/redefine_final_local.zn
+++ b/test/__tests__/variable/redefine_final_local.zn
@@ -1,0 +1,4 @@
+{
+    val a = "some"
+    a = "other" // ERR: Can only set a final variable once.
+}

--- a/test/__tests__/variable/unreached_undefined.zn
+++ b/test/__tests__/variable/unreached_undefined.zn
@@ -1,5 +1,0 @@
-if false {
-    print not_defined
-}
-
-print "ok" // expect: ok


### PR DESCRIPTION
Fixes #11.

An optimization; supposed to make things way faster, but that didn't really turn out to be the case.

These are the times taken by each of the benchmark programs to run
with and without variable existence checking at compile time. Each
benchmark is done three times with the `./x.py bench` command, and the times listed are averages of
the three for each file.

All times are in seconds.

# Without variable existence checking at compile time:

```
- properties.zn: 1.04633
- zoo_batch.zn: 10.000167
- instantiation.zn: 1.45766
- method_call.zn: 0.47333
- zoo.zn: 0.8766
- fib.zn: 3.26866
- equality.zn: 1.50833
- invocation.zn: 0.744667
```

# With variable existence checking at compile time:

```
- properties.zn: 1.04366
- zoo_batch.zn: 10.002666
- instantiation.zn: 1.47366
- method_call.zn: 0.47333
- zoo.zn: 0.865
- fib.zn: 3.226
- equality.zn: 1.46533
- invocation.zn: 0.761
```

Not exactly what I had in mind. Some programs got slightly faster, some somehow became slower. It's not even due to the compiler slowing down due to the hash table call there or anything; I've checked with `zen -t` and the compiler was still quite snappy.

Well, some programs **HAVE** become slightly faster and the slower ones might just be because of the small number of tests.