### PR TITLE
fix: segfault on using -S flag to test GC

### DIFF
--- a/src/gc.odin
+++ b/src/gc.odin
@@ -194,7 +194,7 @@ mark_compiler_roots :: proc(gc: ^GC, compiler: ^Compiler) {
 	cmp := compiler
 	/* Mark each ObjFunction the compiler is compiling into. */
 	for cmp != nil {
-		mark_object(gc, (^Obj)(compiler.function))
+		mark_object(gc, (^Obj)(cmp.function))
 		cmp = cmp.enclosing
 	}
 }


### PR DESCRIPTION
Fixes #4.

Turns out it was just because of a typo in the function that marks roots in the compiler.
To be honest, I don't really know how exactly that typo caused that error, but well, the
test program is running fine now and some similar tests I applied to see if the GC is
actually running seem to pass as well, so, no complaints.