### PR TITLE
Add ifn't and whilen't statements, few other additions too

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -404,3 +404,30 @@ for you to use.
 
 - `push(l, i)`: Add an item `i` to the end of the list `l`.
 - `pop(l)`: Get the last item of the list `l` after removing it from the list.
+
+## The chaotic stuff
+
+You can get these additional cursed features by compiling `zen` while defining
+`CHAOTIC` as `true` in the Odin compiler. The easiest way to make a chaotic build
+is to simply run `./x.py chaotic` in the root directory and you'll get your build
+at `./bin/chaotic/zen`.
+
+These features will **NOT** be tested or given much thought to, since they're just
+funny little things rather than anything serious.
+
+### ifn't and whilen't
+
+The opposite of `if` and `while`.
+
+Just as brain-spinning as `unless` and `until` in Ruby.
+
+```zen
+ifn't true {
+    puts("this will never run")
+}
+
+whilen't i == 11 {
+    puts(i)
+    i = i + 1
+}
+```

--- a/src/chunk.odin
+++ b/src/chunk.odin
@@ -40,6 +40,7 @@ OpCode :: enum {
 	OP_PRINT,
 	OP_JUMP,
 	OP_JUMP_IF_FALSE,
+	OP_JUMP_IF_TRUE,
 	OP_LOOP,
 	OP_CALL,
 	OP_INVOKE,

--- a/src/debug.odin
+++ b/src/debug.odin
@@ -142,6 +142,8 @@ disassemble_instruction :: proc(c: ^Chunk, offset: int) -> int {
 		return jump_instruction("OP_JUMP", 1, c, offset)
 	case .OP_JUMP_IF_FALSE:
 		return jump_instruction("OP_JUMP_IF_FALSE", 1, c, offset)
+	case .OP_JUMP_IF_TRUE:
+		return jump_instruction("OP_JUMP_IF_TRUE", 1, c, offset)
 	case .OP_LOOP:
 		return jump_instruction("OP_LOOP", -1, c, offset)
 	case .OP_CALL:

--- a/src/main.odin
+++ b/src/main.odin
@@ -8,6 +8,9 @@ import "core:strings"
 
 VERSION :: "0.0.1-beta"
 
+/* Chaotic mode is obviously false by default */
+CHAOTIC :: #config(CHAOTIC, false)
+
 /* Config values set on start, mostly for debugging. */
 Config :: struct {
 	compile_only:     bool,
@@ -47,7 +50,13 @@ repl :: proc(vm: ^VM) -> int {
 	vm.name = "REPL"
 	vm.path = "REPL"
 
-	fmt.println("Welcome to zen!")
+	when CHAOTIC {
+		fmt.print("Welcome to zen!")
+		color_red(os.stdout, " (chaotic mode)\n")
+	} else {
+		fmt.println("Welcome to zen!")
+	}
+
 	fmt.println("Press 'Ctrl-D' to exit.")
 	buf: [1024]byte
 

--- a/src/vm.odin
+++ b/src/vm.odin
@@ -489,6 +489,13 @@ run :: proc(vm: ^VM, importer: ImportingModule = nil) -> InterpretResult #no_bou
 					frame.ip = mem.ptr_offset(frame.ip, offset)
 				}
 			}
+		case .OP_JUMP_IF_TRUE:
+			{
+				offset := read_short(frame)
+				if !is_falsey(vm_peek(vm, 0)) {
+					frame.ip = mem.ptr_offset(frame.ip, offset)
+				}
+			}
 		case .OP_LOOP:
 			{
 				offset := read_short(frame)

--- a/x.py
+++ b/x.py
@@ -9,6 +9,8 @@ import platform
 OC = "odin"
 ProcError = subprocess.CalledProcessError
 DEBUG_FLAGS = "-debug -o:none"
+RELEASE_FLAGS = "-o:speed"
+CHAOTIC_FLAGS = f"{RELEASE_FLAGS} -define:CHAOTIC=true"
 
 OUT = "zen"
 DBG_OUT = "dzen"
@@ -41,11 +43,25 @@ def create_release_build():
         os.makedirs("bin/rel", exist_ok=True)
         os.makedirs("bin/test", exist_ok=True)
         subprocess.run(
-            f"{OC} build src/ -out:bin/rel/{OUT} -o:speed".split(), check=True
+            f"{OC} build src/ -out:bin/rel/{OUT} {RELEASE_FLAGS}".split(), check=True
         )
         shutil.copy(f"bin/rel/{OUT}", "bin/test/")
     except ProcError as e:
         print(f"Error while creating release build: {e}", file=sys.stderr)
+        exit(1)
+
+
+def create_chaotic_build():
+    try:
+        print("Compiling in chaotic mode..")
+
+        os.makedirs("bin/chaotic", exist_ok=True)
+        subprocess.run(
+            f"{OC} build src/ -out:bin/chaotic/{OUT} {RELEASE_FLAGS} -define:CHAOTIC=true".split(),
+            check=True,
+        )
+    except ProcError as e:
+        print(f"Error when creating chaotic build: {e}", file=sys.stderr)
         exit(1)
 
 
@@ -129,6 +145,12 @@ def main():
     # release build
     rel_parser = subparsers.add_parser("rel", help="create a release build")
     rel_parser.set_defaults(func=create_release_build)
+
+    # chaotic build
+    chaotic_parser = subparsers.add_parser(
+        "chaotic", help="create a chaotic build (a build with weird extra features)"
+    )
+    chaotic_parser.set_defaults(func=create_chaotic_build)
 
     # benchmark
     bench_parser = subparsers.add_parser("bench", help="run benchmarks")


### PR DESCRIPTION
Fixes #3. Greatest feature of all time.

The `ifn't` and `whilen't` statements are only available when a specific type of compiler build is made. You can build this version of the compiler using `./x.py chaotic` and you'll get the chaotic compiler as `./bin/chaotic/zen`.

Additionally, an exclamation mark can now be used for identifiers, and if you try to have an 'else' without an 'if' the compiler will tell you clearly that you can't do that.