### PR TITLE
Fix list values being unassignable, and add quicksort implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,17 @@
 
 A lightweight dynamically typed programming language written in Odin.
 
+Get started with a hello world!
+
+```zen
+puts "Hello, world!"
+```
+
+# documentation
+
+All the documentation about the language is in the markdown file `DOCUMENTATION.md`
+in the root of this repository.
+
 # development
 
 ## building
@@ -43,4 +54,5 @@ To test everything at once, run:
 
 # contributing
 
-zen may have a lot of bugs and problems lying around, feel free to open an issue or create a pull request if you find any!
+zen may have a lot of bugs and problems lying around, feel free to open an issue
+or create a pull request if you find any!

--- a/examples/quicksort.zn
+++ b/examples/quicksort.zn
@@ -1,0 +1,39 @@
+func partition(arr, lo, hi) {
+    val pivot = arr[hi]
+    var idx = lo - 1
+
+    for var i = lo; i < hi; i = i + 1 {
+        if arr[i] <= pivot {
+            idx = idx + 1
+            val tmp = arr[i]
+            arr[i] = arr[idx]
+            arr[idx] = tmp
+        }
+    }
+
+    idx = idx + 1
+    arr[hi] = arr[idx]
+    arr[idx] = pivot
+
+    return idx
+}
+
+func sort(arr, lo, hi) {
+    if lo >= hi {
+        return
+    }
+
+    var pivot_index = partition(arr, lo, hi)
+
+    sort(arr, lo, pivot_index - 1)
+    sort(arr, pivot_index + 1, hi)
+}
+
+pub func quick_sort(arr) {
+    sort(arr, 0, len(arr) - 1)
+}
+
+var array = [2, 1, -5, 123, 95, 16, -81]
+puts(array)
+quick_sort(array)
+puts(array)

--- a/src/chunk.odin
+++ b/src/chunk.odin
@@ -49,6 +49,7 @@ OpCode :: enum {
 	OP_SUPER_INVOKE,
 	OP_LIST,
 	OP_SUBSCRIPT,
+	OP_SUBSCRIPT_SET,
 	OP_CLOSURE,
 	OP_CLOSE_UPVALUE,
 	OP_RETURN,
@@ -116,13 +117,11 @@ get_line :: proc(lines: [dynamic]int, offset: int) -> int {
 
 /* Initializes a chunk. */
 init_chunk :: proc() -> Chunk {
-	return(
-		Chunk {
-			code = make([dynamic]byte, 0, 0),
-			constants = init_value_array(),
-			lines = make([dynamic]int, 0, 0),
-		} \
-	)
+	return (Chunk {
+				code = make([dynamic]byte, 0, 0),
+				constants = init_value_array(),
+				lines = make([dynamic]int, 0, 0),
+			})
 }
 
 /* Writes a byte to a chunk. */

--- a/src/compiler.odin
+++ b/src/compiler.odin
@@ -524,7 +524,14 @@ subscript :: proc(p: ^Parser, can_assign: bool) {
 	expression(p)
 	consume(p, .RSQUARE, "Expect ']' after index.")
 
-	emit_opcode(p, .OP_SUBSCRIPT)
+	if match(p, .EQUAL) {
+		// Parse right hand side of equals
+		expression(p)
+
+		emit_opcode(p, .OP_SUBSCRIPT_SET)
+	} else {
+		emit_opcode(p, .OP_SUBSCRIPT)
+	}
 }
 
 /* Access or set a instance's property, or access a value from a module. */

--- a/src/debug.odin
+++ b/src/debug.odin
@@ -169,6 +169,8 @@ disassemble_instruction :: proc(c: ^Chunk, offset: int) -> int {
 		return byte_instruction("OP_LIST", c, offset)
 	case .OP_SUBSCRIPT:
 		return simple_instruction("OP_SUBSCRIPT", offset)
+	case .OP_SUBSCRIPT_SET:
+		return simple_instruction("OP_SUBSCRIPT_SET", offset)
 	case .OP_CLOSURE:
 		{
 			offset := offset

--- a/src/vm.odin
+++ b/src/vm.odin
@@ -665,10 +665,10 @@ run :: proc(vm: ^VM, importer: ImportingModule = nil) -> InterpretResult #no_bou
 					defer strings.builder_destroy(&sb)
 
 					for char, idx in zstring.chars {
-						strings.write_rune(&sb, char)
-
 						if int(index) == idx {
 							strings.write_string(&sb, assigned.chars)
+						} else {
+							strings.write_rune(&sb, char)
 						}
 					}
 

--- a/src/vm.odin
+++ b/src/vm.odin
@@ -580,20 +580,22 @@ run :: proc(vm: ^VM, importer: ImportingModule = nil) -> InterpretResult #no_bou
 					list := as_list(a)
 
 					if int(index) >= list.items.count {
-						vm_panic(vm, "Index out of bounds.")
+						vm_panic(vm,
+							fmt.tprintf("Index out of bounds, attempted indexing %d in a %d list.", 
+								int(index), list.items.count))
 						return .INTERPRET_RUNTIME_ERROR
 					}
 
 					vm_push(vm, list.items.values[int(index)])
 				} else {
-					string := as_string(a)
+					zstring := as_string(a)
 
-					if int(index) >= len(string.chars) {
-						vm_panic(vm, "Index out of bounds.")
+					if int(index) >= zstring.len {
+						vm_panic(vm, fmt.tprintf("Index out of bounds, attempted indexing %d in a %d string.", int(index), zstring.len))
 						return .INTERPRET_RUNTIME_ERROR
 					}
 
-					for char, idx in string.chars {
+					for char, idx in zstring.chars {
 						if int(index) == idx {
 							res := utf8.runes_to_string([]rune{char})
 							defer delete(res)
@@ -601,6 +603,77 @@ run :: proc(vm: ^VM, importer: ImportingModule = nil) -> InterpretResult #no_bou
 							break
 						}
 					}
+				}
+			}
+		case .OP_SUBSCRIPT_SET:
+			{
+				c := vm_pop(vm)
+				b := vm_pop(vm)
+				a := vm_pop(vm)
+
+				if !is_list(a) && !is_string(a) {
+					vm_panic(vm, "Can only subscript lists and strings.")
+					return .INTERPRET_RUNTIME_ERROR
+				}
+
+				if !is_number(b) {
+					vm_panic(vm, "List index must be a positive integer.")
+					return .INTERPRET_RUNTIME_ERROR
+				}
+
+				index := as_number(b)
+
+				if math.floor(index) != index || index < 0 {
+					vm_panic(vm, "List index must be a non-negative integer.")
+					return .INTERPRET_RUNTIME_ERROR
+				}
+
+				if is_list(a) {
+					list := as_list(a)
+
+					if int(index) >= list.items.count {
+						vm_panic(vm, fmt.tprintf("Index out of bounds, attempted indexing %d in a %d list.", int(index), list.items.count))
+						return .INTERPRET_RUNTIME_ERROR
+					}
+
+					// Update the list and push it back
+					list.items.values[int(index)] = c
+					vm_push(vm, obj_val(list))
+				} else {
+					if (!is_string(c)) {
+						vm_panic(vm, "Can only set a character in a string.")
+						return .INTERPRET_RUNTIME_ERROR
+					}
+
+					zstring := as_string(a)
+					assigned := as_string(c)
+
+					if (assigned.len != 1) {
+						vm_panic(vm, "Can't reassign a string character to multiple characters.")
+						return .INTERPRET_RUNTIME_ERROR
+					}
+
+					if int(index) >= zstring.len {
+						vm_panic(vm, fmt.tprintf("Index out of bounds, attempted indexing %d in a %d string.", int(index), zstring.len))
+						return .INTERPRET_RUNTIME_ERROR
+					}
+
+					/* Build a new string with the specified index updated.
+					 * I tried to just directly update the existing string but
+					 * that wasn't possible for some reason */
+					sb := strings.builder_make()
+					defer strings.builder_destroy(&sb)
+
+					for char, idx in zstring.chars {
+						strings.write_rune(&sb, char)
+
+						if int(index) == idx {
+							strings.write_string(&sb, assigned.chars)
+						}
+					}
+
+					res := strings.to_string(sb)
+					vm_push(vm, obj_val(copy_string(vm.gc, res)))
 				}
 			}
 		case .OP_CLOSURE:


### PR DESCRIPTION
Closes #18.

The fix was to create a new opcode for the operation of reassigning the elements in a list. As a bonus, I also allowed reassigning characters of a string.

And now that this issue is fixed, I can also add a working implementation of quicksort!